### PR TITLE
Added a second condition for when 'messageendtime' is put into the xml

### DIFF
--- a/openebs/templates/xml/kv15stopmessage.xml
+++ b/openebs/templates/xml/kv15stopmessage.xml
@@ -14,8 +14,8 @@
     <messagetype>{{ object.messagetype }}</messagetype>
     <messagedurationtype>{{ object.messagedurationtype }}</messagedurationtype>
     <messagestarttime>{{ object.messagestarttime|date:"c" }}</messagestarttime>
-    {% if object.messagedurationtype != "REMOVE" %}
-    <messageendtime>{{ object.messageendtime|date:"c" }}</messageendtime>
+    {% if object.messagedurationtype != "REMOVE" and object.messageendtime %}
+        <messageendtime>{{ object.messageendtime|date:"c" }}</messageendtime>
     {% endif %}
     <messagecontent>{{ object.messagecontent }}</messagecontent>
     {% if object.reasontype != "ONGEDEFINIEERD" and object.reasontype != None %}<reasontype>{{ object.reasontype }}</reasontype>


### PR DESCRIPTION
fix #91 
added a second condition for when 'messageendtime' is put into the xml: check if it exists (will always be the case from the openebs site, but maybe not from an external party)