### PR TITLE
Back-up plan to show no journeys without a operating day

### DIFF
--- a/kv1/views.py
+++ b/kv1/views.py
@@ -53,18 +53,18 @@ class LineTripView(LoginRequiredMixin, JSONListResponseMixin, DetailView):
         """
         Forces our output as json and do some queries
         """
-        operating_day = get_operator_date()
         if 'operatingday' in self.request.GET:
             operating_day = parse_date(self.request.GET['operatingday'])
 
-        obj = get_object_or_404(self.model, pk=self.kwargs.get('pk', None))
-        if obj:
-            # Note, the list() is required to serialize correctly
-            # We're filtering on todays trips #
-            journeys = obj.journeys.filter(dates__date=operating_day).order_by('departuretime') \
-                .values('id', 'journeynumber', 'direction', 'departuretime')
-            return {'trips_1': list(journeys.filter(direction=1)), 'trips_2': list(journeys.filter(direction=2))}
-        return obj
+            obj = get_object_or_404(self.model, pk=self.kwargs.get('pk', None))
+            if obj:
+                # Note, the list() is required to serialize correctly
+                # We're filtering on todays trips #
+                journeys = obj.journeys.filter(dates__date=operating_day).order_by('departuretime') \
+                    .values('id', 'journeynumber', 'direction', 'departuretime')
+                return {'trips_1': list(journeys.filter(direction=1)), 'trips_2': list(journeys.filter(direction=2))}
+
+        return {'trips_1': [], 'trips_2': []}
 
 
 # Map views


### PR DESCRIPTION
Just in case somebody bypasses the previously merged blocks on the page of 'ritaanpassingen', the view will also return no journeys