### PR TITLE
Fix search box disappearing on the map pages

### DIFF
--- a/openebs2/static/css/site.css
+++ b/openebs2/static/css/site.css
@@ -116,6 +116,10 @@ span.stop-selection,span.trip-selection{
     width: 250px;
     background-color: #ffffff;
     padding: 5px;
+    /* Leaflet's panes (z-index 400) and controls (800) share the root stacking
+       context with this box, so without a z-index the map paints over it as
+       soon as it renders. Stay below 1000 so the navbar dropdowns win. */
+    z-index: 900;
 }
 .twitter-typeahead {
     width: 100%;


### PR DESCRIPTION
Fixes #234

## Problem

The stop search box (*"Zoek een halte"*) on the map pages flashes into view when the page loads and then disappears.

## Cause

`#autocomplete_holder` is absolutely positioned over the map but has no `z-index`. Leaflet sets `position: relative` on the map container without a `z-index`, so the container never creates a stacking context and its panes (`.leaflet-pane { z-index: 400 }` in the bundled Leaflet 1.9.3) and controls (`800`) land in the root stacking context. A positioned element with `z-index: auto` always paints below positioned elements with a positive `z-index`, regardless of DOM order — so the map paints over the search box the moment its panes are created. Hence the brief flash before Leaflet initialises.

## Fix

Give `#autocomplete_holder` `z-index: 900`: above Leaflet's panes and controls, and deliberately below `1000` so Bootstrap's navbar dropdowns — which open over that same top-right corner — still render on top.

One rule covers both map pages, since `kv15stopmessage_map.html` and `kv15scenario_map.html` share the id.

## Testing

Verified locally against a full stack (PostGIS + RID stop import): the search box stays visible over the map and the typeahead returns stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)