### PR TITLE
Make a clean install work again (requirements.txt + bower.json)

### DIFF
--- a/openebs2/static/bower.json
+++ b/openebs2/static/bower.json
@@ -27,7 +27,11 @@
     "typeahead.js": "~0.11.1",
     "angular": "1.5.0",
     "angular-resource": "1.5.0",
-    "angular-bootstrap": "^1.2.2",
-    "angular-cookies": "^1.5.0"
+    "angular-bootstrap": "1.3.3",
+    "angular-cookies": "1.5.0"
+  },
+  "resolutions": {
+    "jquery": "3.7.1",
+    "angular": "1.5.0"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,13 @@
 Django>=4.2.0,<4.2.99
 #south==1.0.2
-psycopg2==2.9.9
+psycopg2==2.9.10 # 2.9.9 does not build on Python 3.13
 #django-floppyforms
 git+https://github.com/jazzband/django-floppyforms.git
 django-crispy-forms>=2.1.0, <2.1.99
-#jsonfield==3.1.0
+jsonfield==3.1.0 # Imported by kv1/models.py
 django-leaflet==0.29.1
 django-geojson==4.0.0
+setuptools<81 # django-geojson 4.0.0 imports pkg_resources, dropped in setuptools 81 - see #236
 pyzmq # Verification feed
 django-braces==1.15.0
 future==1.0.0


### PR DESCRIPTION
Setting the project up from scratch on a fresh machine currently fails at both the Python and the frontend step. This fixes both. Split out of #234 / #235, which it is otherwise unrelated to.

## requirements.txt

| Problem | Fix |
| --- | --- |
| `jsonfield` is commented out, but `kv1/models.py:8` does `from jsonfield import JSONField` — the app cannot start on a clean install | uncomment `jsonfield==3.1.0` |
| `psycopg2==2.9.9` does not compile on Python 3.13: `error: implicit declaration of function '_PyInterpreterState_Get'` — that private API was removed in 3.13 | bump to `2.9.10`, which fixes exactly this |
| `django-geojson 4.0.0` does `from pkg_resources import DistributionNotFound`; setuptools 81 removed `pkg_resources`, and fresh venvs no longer ship setuptools at all | pin `setuptools<81` as a stopgap |

The setuptools pin is deliberately temporary — #236 tracks upgrading django-geojson to 4.2.0, which dropped the `pkg_resources` import in 4.1.0 and lets the pin go away.

## bower.json

`bower install` fails outright today:

```
bower ECONFLICT Unable to find suitable version for angular
```

`angular-cookies ^1.5.0` resolves to 1.8.3, which demands `angular#1.8.3`, conflicting with the pinned `angular 1.5.0`. Separately, jQuery resolved to **4.0.0** for the loose `>=1.7` range coming from jquery-ui — Bootstrap 3 requires `>=1.9.1 <4`, so that alone would have broken the UI.

- pin `angular-bootstrap` to `1.3.3` (last 1.x, needs only `angular >=1.4.0`) and `angular-cookies` to `1.5.0`, matching the pinned `angular` and `angular-resource`
- add a `resolutions` block for `jquery: 3.7.1` — satisfies bootstrap, jquery-ui and typeahead.js simultaneously — and `angular: 1.5.0`

## Testing

Full local setup on Python 3.13 / PostgreSQL 17 + PostGIS 3.5: `pip install -r requirements.txt` succeeds, `manage.py check` reports no issues, migrations apply, `manage.py import_rid` loads the RID stop/line CSVs, and the app serves the message list and map pages. `bower install` completes, and all eight asset paths referenced from `base.html` and the map templates are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)