### PR TITLE
Add SOCIAL_LOGIN_ENABLED flag so the app runs without SSO

### DIFF
--- a/openebs/signals.py
+++ b/openebs/signals.py
@@ -1,5 +1,6 @@
 from allauth.account.signals import user_logged_in
 from allauth.socialaccount.models import SocialAccount
+from django.conf import settings
 from django.dispatch import receiver
 from django.contrib.auth.models import Permission
 
@@ -8,6 +9,9 @@ from openebs.models import UserProfile
 
 @receiver(user_logged_in)
 def user_logged_in_signal_handler(request, user, **kwargs):
+    if not settings.SOCIAL_LOGIN_ENABLED:
+        return  # No social account to read roles from
+
     social_account = SocialAccount.objects.get(user=request.user)
     roles = social_account.extra_data.get('realm_access', {}).get('roles', [])
 

--- a/openebs2/context_processors.py
+++ b/openebs2/context_processors.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def social_login(request):
+    return {'SOCIAL_LOGIN_ENABLED': settings.SOCIAL_LOGIN_ENABLED}

--- a/openebs2/settings.py
+++ b/openebs2/settings.py
@@ -66,6 +66,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'openebs2.context_processors.social_login',
             ],
         },
     },
@@ -130,6 +131,10 @@ INSTALLED_APPS = (
 
 # Provider specific settings
 SOCIALACCOUNT_PROVIDERS = {}
+
+# SSO login: shows the provider button and syncs permissions from its roles.
+# Turn off in local_settings to use plain Django accounts.
+SOCIAL_LOGIN_ENABLED = True
 
 
 AUTH_PASSWORD_VALIDATORS = [

--- a/openebs2/templates/users/login.html
+++ b/openebs2/templates/users/login.html
@@ -26,12 +26,14 @@
                 </div>
                 <input type="hidden" name="next" value="{{ next }}" />
             </form>
+            {% if SOCIAL_LOGIN_ENABLED %}
             <form action="{% provider_login_url 'keycloak' auth_params='kc_idp_hint=htm' %}" method="post">
                 {% csrf_token %}
                 <label class="control-label requiredField">Inloggen met:</label>
                 <br />
                 <input type="image" alt="Inloggen bij HTM Personenvervoer N.V." src="https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcQoTvMFOybjDV8LOQJTz5Jx1YxWiCZ_jSUB2MGPDkDmY8L0J2kQ" style="width:100px;"/>
             </form>
+            {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
The app currently cannot be run without a Keycloak setup, which makes local development painful.

Two things assume SSO unconditionally:

- `openebs/signals.py` does `SocialAccount.objects.get(user=request.user)` on every `user_logged_in`, so any password login — including a fresh `createsuperuser` — fails with a 500, `SocialAccount matching query does not exist`
- `users/login.html` calls `{% provider_login_url 'keycloak' %}`, which needs a matching `SocialApp` row or `/inloggen/` errors out

Both now sit behind `SOCIAL_LOGIN_ENABLED`, which defaults to `True`, so production behaviour is unchanged. Set it to `False` in `local_settings.py` to work with plain Django accounts. The flag reaches the template through a small context processor.

## Testing

Verified both paths against a full local stack:

| | enabled (+ SocialApp) | disabled (no social rows at all) |
| --- | --- | --- |
| `/inloggen/` | 200, provider button present | 200, button hidden |
| login POST | 302 | 302 |
| permission sync | runs — a plain user with `KV15`/`KV17` roles got `add_messages`, `add_change`, `cancel_lines`, `cancel_alllines`, `add_scenario` | skipped, no 500 |
| `/bericht`, `/kaart`, `/scenario` | 200 | 200 |

The enabled case was checked with a non-superuser so permissions were not masked by `is_superuser`, and the disabled case with zero `SocialApp`/`SocialAccount` rows in the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)