### PR TITLE
Fix the test suite

### DIFF
--- a/ferry/management/commands/sendkv6.py
+++ b/ferry/management/commands/sendkv6.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
             try:
                 msg = FerryKv6Messages.objects.get(operatingday=date, ferry=ferry, journeynumber=journey.journeynumber,
                                                    status=FerryKv6Messages.Status.READY, cancelled=False)
-                if msg.delay > 0 and journey.departuretime + msg.delay > depart_target:
+                if msg.delay is not None and msg.delay > 0 and journey.departuretime + msg.delay > depart_target:
                     continue
 
                 msg.status = FerryKv6Messages.Status.DEPARTED
@@ -66,7 +66,7 @@ class Command(BaseCommand):
             try:
                 msg = FerryKv6Messages.objects.get(operatingday=date, ferry=ferry, journeynumber=journey.journeynumber,
                                                    status=FerryKv6Messages.Status.DEPARTED, cancelled=False)
-                if msg.delay > 0 and journey.departuretime + msg.delay > arrival_target:
+                if msg.delay is not None and msg.delay > 0 and journey.departuretime + msg.delay > arrival_target:
                     continue
 
                 msg.status = FerryKv6Messages.Status.ARRIVED

--- a/kv1/tests/__init__.py
+++ b/kv1/tests/__init__.py
@@ -1,9 +1,0 @@
-import pkgutil
-import unittest
-
-for loader, module_name, is_pkg in pkgutil.walk_packages(__path__):
-    module = loader.find_module(module_name).load_module(module_name)
-    for name in dir(module):
-        obj = getattr(module, name)
-        if isinstance(obj, type) and issubclass(obj, unittest.case.TestCase):
-            exec ('%s = obj' % obj.__name__)

--- a/kv1/tests/test_import_rid.py
+++ b/kv1/tests/test_import_rid.py
@@ -1,4 +1,3 @@
-from unittest.test.test_case import Test
 
 from django.core.management import call_command
 from django.test import TestCase
@@ -45,12 +44,12 @@ class TestRidImporter(TestCase):
 
         # Data
         lines = [
-            ['operator_id','publiccode','name'],
+            ['bison_id','publiccode','name'],
             ['VTN:1049','62','Gulpen - Vaals'],
         ]
         stops = [
-            ['operator_id','name','longitude','latitude','timingpointcode',],
-            ['VTN:15023014','Busstation Perron C', '1', '2','15023014']  # Load an updated name
+            ['operator_id','name','longitude','latitude','timingpointcode','quaycoderef'],
+            ['VTN:15023014','Busstation Perron C', '1', '2','15023014','NL:Q:15023014']  # Load an updated name
         ]
         self.createTestFile('openebs_lines.csv', lines)
         self.createTestFile('openebs_stops.csv', stops)

--- a/openebs/management/commands/verify_messages.py
+++ b/openebs/management/commands/verify_messages.py
@@ -96,10 +96,17 @@ class Command(BaseCommand):
             self.add_stop_for_message(msg, row)
 
         else:
-            msg, created = Kv15Stopmessage.objects.get_or_create(dataownercode=row['DataOwnerCode'],
-                                                                 kv8messagecodedate=row['MessageCodeDate'],
-                                                                 kv8messagecodenumber=row['MessageCodeNumber'],
-                                                                 defaults={'user': self.get_user()})
+            # Updating a message keeps the superseded version around, and it carries the same
+            # KV8 identity, so match the most recent one instead of tripping over the duplicates
+            msg = Kv15Stopmessage.objects.filter(dataownercode=row['DataOwnerCode'],
+                                                 kv8messagecodedate=row['MessageCodeDate'],
+                                                 kv8messagecodenumber=row['MessageCodeNumber']).order_by('id').last()
+            created = msg is None
+            if created:
+                msg = Kv15Stopmessage.objects.create(dataownercode=row['DataOwnerCode'],
+                                                     kv8messagecodedate=row['MessageCodeDate'],
+                                                     kv8messagecodenumber=row['MessageCodeNumber'],
+                                                     user=self.get_user())
 
             if not created:
                 self.log.info("Message confirmed deleted: %s (Stop/TPC %s)" % (msg, row['TimingPointCode']))

--- a/openebs/models.py
+++ b/openebs/models.py
@@ -342,7 +342,7 @@ class Kv15Scenario(models.Model):
 
     def delete_all(self):
         msgs = []
-        for inst in Kv15ScenarioInstance.objects.filter(scenario=self, message__messageendtime__gt=now):
+        for inst in Kv15ScenarioInstance.objects.filter(scenario=self, message__messageendtime__gt=now()):
             inst.message.delete()
             msgs.append(inst.message.to_xml_delete())
 

--- a/openebs/templates/xml/kv17journey.xml
+++ b/openebs/templates/xml/kv17journey.xml
@@ -47,7 +47,7 @@
     {% endif %}
 </KV17MUTATEJOURNEY>
 {% endif %}
-{% if object.journey_details_mutation_message.count > 0 or object.shorten_details.count > 0 and not object.is_recovered %}
+{% if object.journey_details_mutation_message.count > 0 or object.shorten_details.count > 0 %}{% if not object.is_recovered %}
 <KV17MUTATEJOURNEYSTOP>
     <timestamp>{{ object.created|date:"c" }}</timestamp>
 {% for shorten in object.shorten_details.all %}
@@ -75,4 +75,4 @@
     </MUTATIONMESSAGE>
 {% endfor %}
 </KV17MUTATEJOURNEYSTOP>
-{% endif %}
+{% endif %}{% endif %}

--- a/openebs/tests/__init__.py
+++ b/openebs/tests/__init__.py
@@ -1,9 +1,0 @@
-import pkgutil
-import unittest
-
-for loader, module_name, is_pkg in pkgutil.walk_packages(__path__):
-    module = loader.find_module(module_name).load_module(module_name)
-    for name in dir(module):
-        obj = getattr(module, name)
-        if isinstance(obj, type) and issubclass(obj, unittest.case.TestCase):
-            exec ('%s = obj' % obj.__name__)

--- a/openebs/tests/output/kv17_cancel.xml
+++ b/openebs/tests/output/kv17_cancel.xml
@@ -8,6 +8,9 @@
     </KV17JOURNEY>
     <KV17MUTATEJOURNEY>
         <timestamp>...</timestamp>
-        <CANCEL></CANCEL>
+        <CANCEL>
+            <showcancelledtrip>true</showcancelledtrip>
+            <autorecover>false</autorecover>
+        </CANCEL>
     </KV17MUTATEJOURNEY>
 </DOSSIER>

--- a/openebs/tests/output/kv17_mutationmessage.xml
+++ b/openebs/tests/output/kv17_mutationmessage.xml
@@ -14,6 +14,7 @@
             <reasontype>3</reasontype>
             <subreasontype>7</subreasontype>
             <reasoncontent>Boot is vol</reasoncontent>
+            <showcancelledtrip>true</showcancelledtrip>
         </MUTATIONMESSAGE>
     </KV17MUTATEJOURNEYSTOP>
 </DOSSIER>

--- a/openebs/tests/output/kv17_mutationmessage_cancel.xml
+++ b/openebs/tests/output/kv17_mutationmessage_cancel.xml
@@ -8,7 +8,10 @@
     </KV17JOURNEY>
     <KV17MUTATEJOURNEY>
         <timestamp>...</timestamp>
-        <CANCEL></CANCEL>
+        <CANCEL>
+            <showcancelledtrip>true</showcancelledtrip>
+            <autorecover>false</autorecover>
+        </CANCEL>
     </KV17MUTATEJOURNEY>
     <KV17MUTATEJOURNEYSTOP>
         <timestamp>...</timestamp>
@@ -18,6 +21,7 @@
             <reasontype>3</reasontype>
             <subreasontype>7</subreasontype>
             <reasoncontent>Boot is vol en vaart niet</reasoncontent>
+            <showcancelledtrip>true</showcancelledtrip>
         </MUTATIONMESSAGE>
     </KV17MUTATEJOURNEYSTOP>
 </DOSSIER>

--- a/openebs/tests/output/kv17_mutationmessage_complete.xml
+++ b/openebs/tests/output/kv17_mutationmessage_complete.xml
@@ -17,6 +17,7 @@
             <advicetype>1</advicetype>
             <subadvicetype>3</subadvicetype>
             <advicecontent>Pak de volgende boot</advicecontent>
+            <showcancelledtrip>true</showcancelledtrip>
         </MUTATIONMESSAGE>
     </KV17MUTATEJOURNEYSTOP>
 </DOSSIER>

--- a/openebs/tests/output/kv17_reason_basic.xml
+++ b/openebs/tests/output/kv17_reason_basic.xml
@@ -13,6 +13,8 @@
             <subreasontype>24_13</subreasontype>
             <advicetype>1</advicetype>
             <subadvicetype>3_1</subadvicetype>
+            <showcancelledtrip>true</showcancelledtrip>
+            <autorecover>false</autorecover>
         </CANCEL>
     </KV17MUTATEJOURNEY>
 </DOSSIER>

--- a/openebs/tests/output/kv17_reason_full.xml
+++ b/openebs/tests/output/kv17_reason_full.xml
@@ -15,6 +15,8 @@
             <advicetype>1</advicetype>
             <subadvicetype>3_1</subadvicetype>
             <advicecontent>Kom na carnaval maar terug: Ole!</advicecontent>
+            <showcancelledtrip>true</showcancelledtrip>
+            <autorecover>false</autorecover>
         </CANCEL>
     </KV17MUTATEJOURNEY>
 </DOSSIER>

--- a/openebs/tests/test_command_verify.py
+++ b/openebs/tests/test_command_verify.py
@@ -17,9 +17,9 @@ class TestKv8Verify(TestCase):
         cls.user = User.objects.create_user("test_kv8")
 
         # Create two fake sotps
-        stop_a = Kv1Stop(userstopcode=400, dataownercode='HTM', timingpointcode=400, name="Om de ene hoek", location=Point(1, 1))
-        stop_b = Kv1Stop(userstopcode=401, dataownercode='HTM', timingpointcode=401, name="Om de ander hoek", location=Point(1, 1))
-        stop_c = Kv1Stop(userstopcode=402, dataownercode='HTM', timingpointcode=3000402, name="In Lutjebroek", location=Point(1, 1))
+        stop_a = Kv1Stop(userstopcode=400, dataownercode='HTM', timingpointcode=400, quaycoderef='NL:Q:400', name="Om de ene hoek", location=Point(1, 1))
+        stop_b = Kv1Stop(userstopcode=401, dataownercode='HTM', timingpointcode=401, quaycoderef='NL:Q:401', name="Om de ander hoek", location=Point(1, 1))
+        stop_c = Kv1Stop(userstopcode=402, dataownercode='HTM', timingpointcode=3000402, quaycoderef='NL:Q:402', name="In Lutjebroek", location=Point(1, 1))
         stop_a.save()
         stop_b.save()
         stop_c.save()
@@ -40,10 +40,13 @@ class TestKv8Verify(TestCase):
         row = {
             'DataOwnerCode': 'HTM',
             'TimingPointCode': 400,
+            'QuayCode': 'NL:Q:400',
             'MessageCodeDate': now().date().isoformat(),
             'MessageStartTime': now(),
             'MessageEndTime': now()+timedelta(hours=2),
-            'MessageCodeNumber': '24'
+            'MessageCodeNumber': '24',
+            'OriginalMessageCodeDate': now().date().isoformat(),
+            'OriginalMessageCodeNumber': '24'
         }
 
         # Method under test
@@ -67,6 +70,9 @@ class TestKv8Verify(TestCase):
             'TimingPointCode': 400,
             'MessageCodeDate': now().date().isoformat(),
             'MessageCodeNumber': '25',
+            'OriginalMessageCodeDate': now().date().isoformat(),
+            'OriginalMessageCodeNumber': '25',
+            'QuayCode': 'NL:Q:400',
             'MessageContent': "Test content",
             'MessageStartTime': now(),
             'MessageEndTime': now()+timedelta(hours=2),
@@ -125,6 +131,9 @@ class TestKv8Verify(TestCase):
             'TimingPointCode': 400,
             'MessageCodeDate': now().date().isoformat(),
             'MessageCodeNumber': '37',
+            'OriginalMessageCodeDate': now().date().isoformat(),
+            'OriginalMessageCodeNumber': '37',
+            'QuayCode': 'NL:Q:400',
             'MessageContent': "Test content",
             'MessageStartTime': now(),
             'MessageEndTime': now()+timedelta(hours=2),
@@ -147,9 +156,9 @@ class TestKv8Verify(TestCase):
 
         # Method under test
         self.testClass.process_message(row, False)
-        row['TimingPointCode'] = 401
+        row['TimingPointCode'], row['QuayCode'] = 401, 'NL:Q:401'
         self.testClass.process_message(row, False)
-        row['TimingPointCode'] = 3000402
+        row['TimingPointCode'], row['QuayCode'] = 3000402, 'NL:Q:402'
         self.testClass.process_message(row, False)
 
         self.assertEqual(Kv15Stopmessage.objects.count(), count+1)
@@ -165,8 +174,8 @@ class TestKv8Verify(TestCase):
         Now we have proper support for TPC, check we can have message with two linked stops
         """
 
-        stop_d = Kv1Stop(userstopcode=403, dataownercode='HTM', timingpointcode=3000403, name="In Lutjebroek", location=Point(1, 1))
-        stop_e = Kv1Stop(userstopcode=999, dataownercode='VTN', timingpointcode=3000403, name="In Lutjebrk", location=Point(1, 1))
+        stop_d = Kv1Stop(userstopcode=403, dataownercode='HTM', timingpointcode=3000403, quaycoderef='NL:Q:403', name="In Lutjebroek", location=Point(1, 1))
+        stop_e = Kv1Stop(userstopcode=999, dataownercode='VTN', timingpointcode=3000403, quaycoderef='NL:Q:403', name="In Lutjebrk", location=Point(1, 1))
         stop_d.save()
         stop_e.save()
 
@@ -176,6 +185,9 @@ class TestKv8Verify(TestCase):
             'TimingPointCode': 3000403,
             'MessageCodeDate': now().date().isoformat(),
             'MessageCodeNumber': '50',
+            'OriginalMessageCodeDate': now().date().isoformat(),
+            'OriginalMessageCodeNumber': '50',
+            'QuayCode': 'NL:Q:403',
             'MessageContent': "Test content some more for two vervoerders",
             'MessageStartTime': now(),
             'MessageEndTime': now()+timedelta(hours=2),
@@ -219,6 +231,9 @@ class TestKv8Verify(TestCase):
             'TimingPointCode': 400,
             'MessageCodeDate': now().date().isoformat(),
             'MessageCodeNumber': '26',
+            'OriginalMessageCodeDate': now().date().isoformat(),
+            'OriginalMessageCodeNumber': '26',
+            'QuayCode': 'NL:Q:400',
             'MessageContent': "Test content",
             'MessageStartTime': now(),
             'MessageEndTime': now()+timedelta(hours=2),
@@ -272,7 +287,8 @@ class TestKv8Verify(TestCase):
         Test an already deleted message is marked as such, and the end time is about now
         """
         a = Kv15Stopmessage(dataownercode='HTM', user=self.user, messagecodedate=datetime(2013, 11, 17),
-                            messagecodenumber=30)
+                            messagecodenumber=30, kv8messagecodedate=datetime(2013, 11, 17),
+                            kv8messagecodenumber=30)
         a.save()
         a.delete()
         a.set_status(MessageStatus.DELETED)
@@ -283,6 +299,7 @@ class TestKv8Verify(TestCase):
         row = {
             'DataOwnerCode': 'HTM',
             'TimingPointCode': 400,
+            'QuayCode': 'NL:Q:400',
             'MessageCodeDate': '2013-11-17',
             'MessageCodeNumber': '30'
         }
@@ -299,7 +316,9 @@ class TestKv8Verify(TestCase):
         """
         Test a message that was deleted
         """
-        a = Kv15Stopmessage(dataownercode='HTM', user=self.user, messagecodedate=datetime(2013, 11, 17), messagecodenumber=31)
+        a = Kv15Stopmessage(dataownercode='HTM', user=self.user, messagecodedate=datetime(2013, 11, 17),
+                            messagecodenumber=31, kv8messagecodedate=datetime(2013, 11, 17),
+                            kv8messagecodenumber=31)
         a.save()
         self.assertEqual(a.status, MessageStatus.SAVED)
         self.assertEqual(a.isdeleted, False)
@@ -309,6 +328,7 @@ class TestKv8Verify(TestCase):
         row = {
             'DataOwnerCode': 'HTM',
             'TimingPointCode': 400,
+            'QuayCode': 'NL:Q:400',
             'MessageCodeDate': '2013-11-17',
             'MessageCodeNumber': '31'
         }
@@ -333,13 +353,15 @@ class TestKv8Verify(TestCase):
         row = {
             'DataOwnerCode': 'HTM',
             'TimingPointCode': 400,
+            'QuayCode': 'NL:Q:400',
             'MessageCodeDate': '2013-11-17',
             'MessageCodeNumber': '38'
         }
         # Method under test
         self.testClass.process_message(row, True)
 
-        a = Kv15Stopmessage.objects.get(messagecodenumber=38)
+        # Unknown messages are created with a fresh openEBS number, so find it by its KV8 one
+        a = Kv15Stopmessage.objects.get(kv8messagecodenumber=38)
         self.assertEqual(a.status, MessageStatus.DELETE_CONFIRMED)
         self.assertEqual(a.isdeleted, True)
         self.assertLess((now() - a.messageendtime), timedelta(seconds=30), "Time wasn't set right")
@@ -354,7 +376,9 @@ class TestKv8Verify(TestCase):
         a = Kv15Stopmessage(dataownercode='HTM',
                             user=self.user,
                             messagecodedate=datetime(2013, 11, 17),
-                            messagecodenumber=messagecodenumber)
+                            messagecodenumber=messagecodenumber,
+                            kv8messagecodedate=datetime(2013, 11, 17),
+                            kv8messagecodenumber=messagecodenumber)
         a.save()
         self.assertEqual(a.status, MessageStatus.SAVED)
         self.assertEqual(a.isdeleted, False)
@@ -363,12 +387,13 @@ class TestKv8Verify(TestCase):
         row = {
             'DataOwnerCode': 'HTM',
             'TimingPointCode': 400,
+            'QuayCode': 'NL:Q:400',
             'MessageCodeDate': '2013-11-17',
             'MessageCodeNumber': str(messagecodenumber)
         }
         # Method under test
         self.testClass.process_message(row, True)
-        row['TimingPointCode'] = 401
+        row['TimingPointCode'], row['QuayCode'] = 401, 'NL:Q:401'
         self.testClass.process_message(row, True)
 
         a = Kv15Stopmessage.objects.get(pk=a.pk) # Get latest from db
@@ -384,7 +409,8 @@ class TestKv8Verify(TestCase):
         """
         When we update a message, it sends a delete followed by an update - check that works
         """
-        a = Kv15Stopmessage(dataownercode='HTM', user=self.user, messagecodedate=now().date(), messagecodenumber=32)
+        a = Kv15Stopmessage(dataownercode='HTM', user=self.user, messagecodedate=now().date(), messagecodenumber=32,
+                            kv8messagecodedate=now().date(), kv8messagecodenumber=32)
         a.messagecontent = "Bla!"
         a.status = MessageStatus.CONFIRMED
         a.save()
@@ -398,16 +424,21 @@ class TestKv8Verify(TestCase):
         delete_row = {
             'DataOwnerCode': 'HTM',
             'TimingPointCode': 400,
+            'QuayCode': 'NL:Q:400',
             'MessageCodeDate': now().date().isoformat(),
             'MessageCodeNumber': '32'
         }
         add_row = {
             'DataOwnerCode': 'HTM',
             'TimingPointCode': 401,
+            'QuayCode': 'NL:Q:401',
             'MessageCodeDate': now().date().isoformat(),
             'MessageStartTime': now(),
             'MessageEndTime': now()+timedelta(hours=2),
-            'MessageCodeNumber': '32'
+            'MessageCodeNumber': '32',
+            # The update carries the message's new number, the delete the one it replaced
+            'OriginalMessageCodeDate': now().date().isoformat(),
+            'OriginalMessageCodeNumber': str(a.messagecodenumber)
         }
         # Method under test
         self.testClass.process_message(delete_row, True)
@@ -431,6 +462,9 @@ class TestKv8Verify(TestCase):
             'TimingPointCode': 400,
             'MessageCodeDate': now().date().isoformat(),
             'MessageCodeNumber': '35',
+            'OriginalMessageCodeDate': now().date().isoformat(),
+            'OriginalMessageCodeNumber': '35',
+            'QuayCode': 'NL:Q:400',
             'MessageContent': None,
             'MessageStartTime': now(),
             'MessageEndTime': now()+timedelta(hours=2),

--- a/openebs/tests/test_kv15_xml.py
+++ b/openebs/tests/test_kv15_xml.py
@@ -53,7 +53,7 @@ class TestKv15MessageXmlModel(XmlTest):
         m1.messagetype = MESSAGETYPE[1][0]
         m1.messagedurationtype = MESSAGEDURATIONTYPE[1][0]
         m1.reasontype = REASONTYPE[1][0]
-        m1.subreasontype = SUBREASONTYPE[1][0]
+        m1.subreasontype = '11'  # Literal: the expected XML pins this, the choice order does not
         m1.reasoncontent = "Uitleg oorzaak"
         m1.effecttype = EFFECTTYPE[1][0]
         m1.subeffecttype = SUBEFFECTTYPE[1][0]

--- a/openebs/tests/test_kv17_xml.py
+++ b/openebs/tests/test_kv17_xml.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import User
 from django.contrib.gis.geos import Point
 
 from kv1.models import Kv1Stop, Kv1Line, Kv1Journey
-from openebs.models import Kv17Change, Kv17StopChange, Kv17JourneyChange
+from openebs.models import Kv17Change, Kv17MutationMessage, Kv17JourneyChange
 from utils.xml_test import XmlTest
 
 
@@ -72,8 +72,8 @@ class TestKv17MessageXmlModel(XmlTest):
         change = Kv17Change(dataownercode='HTM', line=self.line, journey=journey, operatingday=datetime(2016, 4, 1),
                             is_cancel=False)
         change.save()
-        stop_change = Kv17StopChange(change=change, type=5, stop=self.haltes[0], stoporder=1,
-                                     reasontype=3, subreasontype=7, reasoncontent="Boot is vol")
+        stop_change = Kv17MutationMessage(change=change, stop=self.haltes[0], passagesequencenumber=1,
+                                          reasontype=3, subreasontype=7, reasoncontent="Boot is vol")
         stop_change.save()
 
         # Have to pad with "DOSSIER" since otherwise we have invalid XML
@@ -98,8 +98,8 @@ class TestKv17MessageXmlModel(XmlTest):
 
         change = Kv17Change(dataownercode='HTM', line=self.line, journey=journey, operatingday=datetime(2016, 4, 1))
         change.save()
-        stop_change = Kv17StopChange(change=change, type=5, stop=self.haltes[0], stoporder=1,
-                                     reasontype=3, subreasontype=7, reasoncontent="Boot is vol en vaart niet")
+        stop_change = Kv17MutationMessage(change=change, stop=self.haltes[0], passagesequencenumber=1,
+                                          reasontype=3, subreasontype=7, reasoncontent="Boot is vol en vaart niet")
         stop_change.save()
         self.assertXmlEqual("<DOSSIER>%s</DOSSIER>" % change.to_xml(),
                             self.getCompareXML('openebs/tests/output/kv17_mutationmessage_cancel.xml'))

--- a/openebs/tests/test_model_log.py
+++ b/openebs/tests/test_model_log.py
@@ -12,4 +12,4 @@ class TestKv15LogModel(TestCase):
         m.save() # This assigns an codenumber
         Kv15Log.create_log_entry(m, "10.0.0.1")
 
-        self.assertEquals(Kv15Log.objects.count(), 1)
+        self.assertEqual(Kv15Log.objects.count(), 1)

--- a/openebs/tests/test_views_permissions.py
+++ b/openebs/tests/test_views_permissions.py
@@ -31,8 +31,8 @@ class TestViewPermissions(TestCase):
     def test_view_messages(self):
         response = self.client.get(reverse('msg_index'))
         self.assertEqual(response.status_code, 200)
-        self.assertEquals(len(response.context['active_list']), 0)
-        self.assertEquals(len(response.context['archive_list']), 0)
+        self.assertEqual(len(response.context['active_list']), 0)
+        self.assertEqual(len(response.context['archive_list']), 0)
 
         # Create NS message
         msg = TestUtils.create_message_default(self.user)
@@ -46,27 +46,27 @@ class TestViewPermissions(TestCase):
 
         response = self.client.get(reverse('msg_index'))
         self.assertEqual(response.status_code, 200)
-        self.assertEquals(len(response.context['active_list']), 1)
-        self.assertEquals(response.context['active_list'][0].messagecontent, "NS zet bussen in")
-        self.assertEquals(len(response.context['archive_list']), 0)
+        self.assertEqual(len(response.context['active_list']), 1)
+        self.assertEqual(response.context['active_list'][0].messagecontent, "NS zet bussen in")
+        self.assertEqual(len(response.context['archive_list']), 0)
 
     def test_view_messages_all(self):
         response = self.client.get(reverse('msg_index')+"?all=true")
         self.assertEqual(response.status_code, 200)
-        self.assertEquals(len(response.context['active_list']), Kv15Stopmessage.objects.filter(dataownercode='NS').count())
-        self.assertEquals(len(response.context['archive_list']), 0)
+        self.assertEqual(len(response.context['active_list']), Kv15Stopmessage.objects.filter(dataownercode='NS').count())
+        self.assertEqual(len(response.context['archive_list']), 0)
 
         view_all_perm = Permission.objects.get(codename='view_all')
         self.user.user_permissions.add(view_all_perm)
 
         response = self.client.get(reverse('msg_index'))
         self.assertEqual(response.status_code, 200)
-        self.assertEquals(len(response.context['active_list']), Kv15Stopmessage.objects.filter(messageendtime__gt=now(),
+        self.assertEqual(len(response.context['active_list']), Kv15Stopmessage.objects.filter(messageendtime__gt=now(),
                                                                                                isdeleted=False).count())
 
-        archive_count = Kv15Stopmessage.objects.filter(Q(messageendtime__lt=now) | Q(isdeleted=True),
+        archive_count = Kv15Stopmessage.objects.filter(Q(messageendtime__lt=now()) | Q(isdeleted=True),
                                                        messagestarttime__gt=now() - timedelta(days=3)).count()
-        self.assertEquals(len(response.context['archive_list']), archive_count)
+        self.assertEqual(len(response.context['archive_list']), archive_count)
 
         self.user.user_permissions.remove(view_all_perm)
         self.user.save()

--- a/utils/views.py
+++ b/utils/views.py
@@ -85,8 +85,11 @@ class ExternalMessagePushMixin(object):
         for destination in sorted(settings, key=lambda k: k['priority']):
             if not destination['enabled']:
                 continue
-            if self.message_type is None or self.message_type not in destination['endpoints']:
+            if self.message_type is None:
                 raise ImproperlyConfigured("Endpoint type isn't registered")
+            if self.message_type not in destination['endpoints']:
+                # Not every subscriber takes every message type - ndovloket_rig has no KV6
+                continue
             if self.namespace == '' or self.namespace is None:
                 raise ImproperlyConfigured("Namespace isn't configured")
             if self.dossier == '' or self.dossier is None:


### PR DESCRIPTION
The suite has not run in a long time. Test discovery itself was broken: `openebs/tests/__init__.py` and `kv1/tests/__init__.py` imported their modules by hand through `loader.find_module(...).load_module(...)`, and Python 3.12 removed `find_module` — so the whole suite died at import and **zero tests ran**. Django has discovered `test*.py` on its own since 1.6, so the initialisers can simply be empty.

With discovery working, 24 of 36 tests failed. **40 tests now run and pass.**

## Five real bugs the tests could not report

| Where | Bug |
| --- | --- |
| `openebs/models.py:345` | `Kv15Scenario.delete_all()` filtered on `messageendtime__gt=now` — the function, never called. Deleting a planned scenario raised `TypeError`. |
| `ferry/.../sendkv6.py:49,69` | `msg.delay > 0` on a nullable field, so a ferry message without a delay crashed the command. The init branch at line 32 already guarded for `None`; two of three places forgot. |
| `utils/views.py:88` | `get_pushers()` raised `ImproperlyConfigured` when *any* subscriber lacked the message type, and `ndovloket_rig` has no KV6 endpoint — so `Kv6PushMixin` could not even be imported. Now skips subscribers that do not take the type. |
| `templates/xml/kv17journey.xml:50` | `mutation > 0 or shorten > 0 and not is_recovered` — `and` binds tighter than `or`, so the `not is_recovered` guard never applied to mutation messages and a **recover still emitted a mutation-message block**. |
| `.../verify_messages.py:99` | KV8 deletes were matched with `get_or_create()` on the KV8 identity, but updating a message leaves the superseded version behind carrying that same identity, so the lookup raised `MultipleObjectsReturned`. Now matches the most recent one. |

The last two change what goes out to subscribers, so they deserve a careful look. For the KV17 one the expected-output fixture already documented the intended behaviour (no mutation block on recover), which is what convinced me the precedence was accidental.

## The rest is fixture rot

Tests written against behaviour that has since moved on:

- stops are matched by `QuayCode` now, not `timingpointcode`, and message identity moved to `OriginalMessageCode*` — the KV8 rows in `test_command_verify` predate both
- mutation messages moved to their own `Kv17MutationMessage` model; the tests still built `Kv17StopChange(type=5)`, which no longer feeds the template
- KV17 cancels gained `showcancelledtrip` and `autorecover` (#214) — added to the expected XML
- `import_rid` reads `bison_id` and `quaycoderef`; the test CSV still used `operator_id` and omitted the quay column
- `SUBREASONTYPE` gained an entry, so `SUBREASONTYPE[1][0]` no longer matched the literal in the expected XML — pinned to the literal instead
- `assertEquals` and `unittest.test` are gone in Python 3.12

## Testing

`manage.py test` → **40 tests, OK**, run twice. Also re-ran the app smoke checks afterwards, since this touches the KV17 template and three commands: login plus `/bericht`, `/kaart`, `/haltes.geojson`, `/stop/search.json`, `/scenario`, `/ritaanpassing` and `/admin/` all still return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)